### PR TITLE
Fixing the enemy dying transition with pausing and command prompt, fixing enabling grant favor

### DIFF
--- a/Assets/Scripts/Himanshu/EnemyController.cs
+++ b/Assets/Scripts/Himanshu/EnemyController.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Bolt;
 using Cinemachine;
+using rachael.FavorSystem;
 using rachael.qte;
 using TMPro;
 using UnityEngine;
@@ -245,11 +246,17 @@ namespace Himanshu
                 var playerInteract = m_player.GetComponent<PlayerInteract>();
                 if (playerInteract.m_invincible || playerInteract.m_debugInvincible)
                     yield break;
-                
-                if(Time.timeScale == 0f)
-                    yield return null;
-                
-            
+
+                if(FindObjectOfType<GameCommandPrompt>(true).gameObject.activeSelf)
+                {
+                    FindObjectOfType<FavorSystem>(true).CloseCommandPrompt();
+                }
+                if (FindObjectOfType<PauseMenu>(true).gameObject.activeSelf)
+                {
+                    FindObjectOfType<PauseMenu>(true).Unpause();
+                }
+
+
                 if (dangerLevel == eDanger.yellow)
                 {
                     yield break;

--- a/Assets/Scripts/Himanshu/NarratorTrigger.cs
+++ b/Assets/Scripts/Himanshu/NarratorTrigger.cs
@@ -51,8 +51,9 @@ namespace Himanshu
 
             m_player.m_invincible = false;
 
-            if (gameObject.name != "Hub") 
+            if (gameObject.name != "Hub" && _collider.CompareTag("Player")) 
             {
+                Debug.Log("Player entered new room");
                 FavorSystem.startTimer = true;
                 if(!m_player.m_isDying)
                     FavorSystem.m_grantSpecial = true;

--- a/Assets/Scripts/Himanshu/PlayerInteract.cs
+++ b/Assets/Scripts/Himanshu/PlayerInteract.cs
@@ -262,7 +262,7 @@ namespace Himanshu
             }
 
 #else
-            if (Input.GetKeyDown(KeyCode.Escape)  && (Math.Abs(Time.timeScale - 1) < 0.1f || FindObjectOfType<FavorSystem>().m_timeStop))
+            if (Input.GetKeyDown(KeyCode.Escape)  && !m_isDying && (Math.Abs(Time.timeScale - 1) < 0.1f || FindObjectOfType<FavorSystem>().m_timeStop))
             {
                 PauseScreen.SetActive(true);
                 FindObjectOfType<FavorSystem>().m_continueCounting = false;


### PR DESCRIPTION
We disable both menus during enemy attack coroutine and the enabling of special menu when hiding or dying